### PR TITLE
inputs.config

### DIFF
--- a/siem/splunk/twistlock/inputs.config
+++ b/siem/splunk/twistlock/inputs.config
@@ -1,0 +1,17 @@
+[script://./bin/poll-incidents.py] 
+disabled = 0 
+
+[script://./bin/poll-forensics.py] 
+disabled = 0 
+
+[script://$SPLUNK_HOME\etc\apps\twistlock\bin\poll-incidents.py] 
+disabled = false 
+index = main 
+interval = 30 
+sourcetype = twistlock:incident 
+
+[script://$SPLUNK_HOME\etc\apps\twistlock\bin\poll-forensics.py] 
+disabled = false 
+index = main 
+interval = 30 
+sourcetype = twistlock:forensicdata


### PR DESCRIPTION
[script://./bin/poll-incidents.py] 
disabled = 0

[script://./bin/poll-forensics.py] 
disabled = 0

[script://$SPLUNK_HOME\etc\apps\twistlock\bin\poll-incidents.py] 
disabled = false 
index = main 
interval = 30 
sourcetype = twistlock:incident

[script://$SPLUNK_HOME\etc\apps\twistlock\bin\poll-forensics.py]] 
disabled = false 
index = main 
interval = 30 
sourcetype = twistlock:forensicdata