### PR TITLE
Update poll_incidents.py

### DIFF
--- a/siem/splunk/twistlock/bin/poll_incidents.py
+++ b/siem/splunk/twistlock/bin/poll_incidents.py
@@ -102,9 +102,17 @@ def get_incidents(console_url, auth_token, project_list):
                 print(highest_serialNum, file=file)
     
     # Write the collected info to a file for poll-forensics.py
-    with open(forensics_file, 'a') as f:
-        json.dump(field_extracts, f)
-
+    if os.path.isfile(forensics_file):
+        forensics = json.load(open(forensics_file))
+            for event in forensics:
+                if event not in field_extracts:
+                    field_extracts.append(event)
+             with open(forensics_file, 'w') as f:
+                json.dump(field_extracts, f)                                                                                           
+    else:
+        with open(forensics_file, 'w') as f:
+            json.dump(field_extracts, f)
+            
 if __name__ == "__main__":
     config = json.load(open(config_file))
 

--- a/siem/splunk/twistlock/bin/poll_incidents.py
+++ b/siem/splunk/twistlock/bin/poll_incidents.py
@@ -107,7 +107,7 @@ def get_incidents(console_url, auth_token, project_list):
             for event in forensics:
                 if event not in field_extracts:
                     field_extracts.append(event)
-             with open(forensics_file, 'w') as f:
+            with open(forensics_file, 'w') as f:
                 json.dump(field_extracts, f)                                                                                           
     else:
         with open(forensics_file, 'w') as f:


### PR DESCRIPTION
Currently a race condition can occur if poll_incidents.py is ran twice and appends to forensics_file.txt 
It will result in the JSONDecodeError stated above.
This can be resolved by testing to see if the file exists. 
If it doesn't just write the file don't append to it. 
The following code should resolve this issue.