### PR TITLE
Update poll_incidents.py on write

### DIFF
--- a/siem/splunk/twistlock/bin/poll_incidents.py
+++ b/siem/splunk/twistlock/bin/poll_incidents.py
@@ -97,7 +97,7 @@ def get_incidents(console_url, auth_token, project_list):
         # Update the checkpoint file
         if highest_serialNum >= last_serialNum_indexed:
             with open(checkpoint_file, "w") as f:
-                f.write(highest_serialNum)
+                f.write(str(highest_serialNum))
 
     # Write the collected info to a file for poll-forensics.py.
     # If forensics file already exists append newly-collected incidents to what


### PR DESCRIPTION
Hacky way to fix until better fix can be implemented.
Currently receiving this error.
 
```
Traceback (most recent call last):
  File "twistlock/bin/poll_incidents.py", line 144, in <module>
    get_incidents(console_url, auth_token, projects)
  File "twistlock/bin/poll_incidents.py", line 100, in get_incidents
    f.write(highest_serialNum)
TypeError: write() argument must be str, not int
```

Which cascades into an issue afterwards. 

```
Unexpected content in checkpoint file
invalid literal for int() with base 10: ''
```