### PR TITLE
Recommend changing config.json to list of consoles

### DIFF
--- a/siem/splunk/twistlock/bin/data/config.json
+++ b/siem/splunk/twistlock/bin/data/config.json
@@ -1,10 +1,14 @@
 {
-  "credentials": {
-    "username": "",
-    "password": ""
-  },
-  "console": {
-    "url": "",
-    "projects": ["Central Console"]
-  }
+  "consoles": 
+  [
+    {
+      "url": "",
+      "credentials": 
+        {
+          "username": "",
+          "password": ""
+        },
+      "projects": ["Central Console"]
+    }
+  ]
 }


### PR DESCRIPTION
Major breaking change, however IMHO this allows the use of multiple consoles from a single source.
Submitting PR to update poll_incidents.py to adhere to new configuration.
This will greatly benefit triaging of alert being able to determine which console it was generated from.
(ie Dev,Test,Prod)