### PR TITLE
Update opa rule container-capabilities.rego

### DIFF
--- a/opa-rego-policies/container-capabilities.rego
+++ b/opa-rego-policies/container-capabilities.rego
@@ -1,14 +1,39 @@
-# Matches when a container in a pod adds a specified capability
+# Matches when a container adds a specified capability
 
 match[{"msg": msg}] {
-    operations := {"CREATE"}
-    operations[input.request.operation]
-    input.request.kind.kind == "Pod"
-
-    containers := input.request.object.spec.containers[_]
-    denied_capabilities := {"CAP_SYS_ADMIN", "CAP_SYS_CHROOT"}
-    present_capabilities := {containers.securityContext.capabilities.add[_]}
-
+    spec := get_pod_spec(input.request.object)
+    containers := array.concat(object.get(spec, "initContainers", []), object.get(spec, "containers", []))
+    container := containers[_]
+    
+    denied_capabilities := {"SYS_ADMIN", "NET_ADMIN"}
+    
+    present_capabilities := {container.securityContext.capabilities.add[_]}
     count(denied_capabilities & present_capabilities) > 0
-    msg := sprintf("container '%v' is adding one of the following capabilities: %v", [containers.name, concat(", ", denied_capabilities)])
+    msg := sprintf("container '%v' is adding one of the following capabilities: %v", [container.name, concat(", ", denied_capabilities)])
+}
+
+get_pod_spec(obj) = spec {
+  obj.kind == "Pod"
+  spec := obj.spec
+} {
+  obj.kind == "CronJob"
+  spec := obj.spec.jobTemplate.spec.template.spec
+} {
+  obj.kind == "ReplicaSet"
+  spec := obj.spec.template.spec
+} {
+  obj.kind == "ReplicationController"
+  spec := obj.spec.template.spec
+} {
+  obj.kind == "Deployment"
+  spec := obj.spec.template.spec
+} {
+  obj.kind == "StatefulSet"
+  spec := obj.spec.template.spec
+} {
+  obj.kind == "DaemonSet"
+  spec := obj.spec.template.spec
+} {
+  obj.kind == "Job"
+  spec := obj.spec.template.spec
 }


### PR DESCRIPTION
- Catch all objects that may contain containers.
- Use the k8s capability format, without the `CAP_`prefix.
- Replace `SYS_CHROOT` with `NET_ADMIN`, as `SYS_CHROOT` is one of the default capabilities, which this policy can't catach.

### Tested on
Should fail:
```
apiVersion: v1
kind: Pod
metadata:
  name: security-context-demo-4
spec:
  containers:
  - name: sec-ctx-4
    image: gcr.io/google-samples/node-hello:1.0
    securityContext:
      capabilities:
        add: ["NET_ADMIN", "SYS_TIME"]
```
Should pass:
```
apiVersion: v1
kind: Pod
metadata:
  name: security-context-demo-4
spec:
  containers:
  - name: sec-ctx-4
    image: gcr.io/google-samples/node-hello:1.0
    securityContext:
      capabilities:
        add: ["NET_RAW", "SYS_TIME"]
```